### PR TITLE
Relax the upper version bound on activesupport

### DIFF
--- a/pager_duty-connection.gemspec
+++ b/pager_duty-connection.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "faraday", "~> 0.14"
   gem.add_dependency "faraday_middleware", "~> 0.12.0"
-  gem.add_dependency "activesupport", ">= 3.2", "< 5.0"
+  gem.add_dependency "activesupport", ">= 3.2"
   gem.add_dependency "hashie", ">= 1.2"
 end


### PR DESCRIPTION
To address CVEs in activesupport